### PR TITLE
Redesign Leaderboard & Wheel pages

### DIFF
--- a/web/components/Leaderboard.vue
+++ b/web/components/Leaderboard.vue
@@ -1,14 +1,32 @@
 <script setup lang="ts">
 import api from "@composables/axios";
 import { ArrowClockwise24Filled } from "@vicons/fluent";
+import { formatDate } from "@composables/utils";
 import { onMounted, ref, Ref } from "vue";
 import { VaButton, VaDivider, VaIcon } from "vuestic-ui";
 
 document.title = "水星排行 - 水星人的夢幻樂園";
 
 const leaderboard: Ref<UserRank[]> = ref([]);
+const lastRefreshTime = ref("");
+let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+
+function nowTime(): string {
+    const d = new Date();
+    const date = formatDate(d);
+    const h = d.getHours().toString().padStart(2, "0");
+    const min = d.getMinutes().toString().padStart(2, "0");
+    const s = d.getSeconds().toString().padStart(2, "0");
+    return `已於 ${date} ${h}:${min}:${s} 更新`;
+}
 
 function loadLeaderboard() {
+    lastRefreshTime.value = nowTime();
+    if (refreshTimer) clearTimeout(refreshTimer);
+    refreshTimer = setTimeout(() => {
+        lastRefreshTime.value = "";
+    }, 5000);
+
     api.get("/api/leaderboard")
         .then((response) => {
             leaderboard.value = response.data
@@ -114,26 +132,32 @@ function podiumSize(rank: number): string {
     >
         <div class="w-full max-w-[1200px] mx-auto">
             <!-- Header -->
-            <div
-                class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6 px-4"
-            >
-                <div>
-                    <h1 class="text-3xl font-bold text-neutral-100">
-                        水星排行
-                    </h1>
-                    <p class="text-sm text-zinc-400 mt-1">
+            <div class="mb-6 px-4">
+                <h1 class="text-3xl font-bold text-neutral-100">水星排行</h1>
+                <div class="mt-1 flex items-center gap-1.5">
+                    <p class="text-sm text-zinc-400">
                         每次直播獲得的水星幣都會在這裡顯示，致敬貢獻最多的水星人
                     </p>
+                    <VaButton
+                        preset="secondary"
+                        color="warning"
+                        :disabled="!!lastRefreshTime"
+                        @click="loadLeaderboard()"
+                        class="refresh-btn shrink-0 ml-4 rounded-full px-3 py-1 !normal-case transition-all duration-300 hover:shadow-[0_0_12px_rgba(234,179,8,0.25)]"
+                    >
+                        <VaIcon
+                            size="small"
+                            :class="{ 'animate-spin': lastRefreshTime }"
+                        >
+                            <ArrowClockwise24Filled />
+                        </VaIcon>
+                        <span
+                            class="ml-1 text-xs tabular-nums bg-gradient-to-r from-yellow-300 via-yellow-400 to-amber-400 bg-clip-text text-transparent font-semibold"
+                        >
+                            {{ lastRefreshTime || "重新整理" }}
+                        </span>
+                    </VaButton>
                 </div>
-                <VaButton
-                    preset="plain"
-                    color="info"
-                    @click="loadLeaderboard()"
-                    class="self-start"
-                >
-                    <VaIcon><ArrowClockwise24Filled /></VaIcon>
-                    <span class="ml-1 text-sm">重新整理</span>
-                </VaButton>
             </div>
 
             <!-- Top 3 Podium -->
@@ -295,5 +319,18 @@ function podiumSize(rank: number): string {
             transparent 32rem
         ),
         linear-gradient(135deg, #0f1117 0%, #16191f 48%, #101318 100%);
+}
+
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.animate-spin {
+    animation: spin 0.8s linear infinite;
 }
 </style>

--- a/web/components/Leaderboard.vue
+++ b/web/components/Leaderboard.vue
@@ -1,16 +1,8 @@
 <script setup lang="ts">
 import api from "@composables/axios";
-import { onMounted, ref, Ref } from "vue";
-import {
-    VaDataTable,
-    VaButton,
-    VaIcon,
-    VaDivider,
-    VaScrollContainer,
-    VaCard,
-} from "vuestic-ui";
 import { ArrowClockwise24Filled } from "@vicons/fluent";
-import ViewportHeight from "./ViewportHeight.vue";
+import { onMounted, ref, Ref } from "vue";
+import { VaButton, VaDivider, VaIcon } from "vuestic-ui";
 
 document.title = "水星排行 - 水星人的夢幻樂園";
 
@@ -22,7 +14,7 @@ function loadLeaderboard() {
             leaderboard.value = response.data
                 .map((u: User) => {
                     return {
-                        rank: 0, // Placeholder for rank, will be assigned later,
+                        rank: 0,
                         youtube: u.youtube,
                         coin: u.coin,
                         display: u.display,
@@ -30,14 +22,13 @@ function loadLeaderboard() {
                     } as UserRank;
                 })
                 .sort((a: UserRank, b: UserRank) => {
-                    return a.coin < b.coin ? 1 : -1; // Sort by coin in descending order
+                    return a.coin < b.coin ? 1 : -1;
                 })
                 .map((r: UserRank, index: number) => {
-                    r.rank = index + 1; // Assign rank based on the sorted order
+                    r.rank = index + 1;
                     return r;
                 })
                 .slice(0, 50);
-            console.log(leaderboard.value);
         })
         .catch((error) => {
             console.error("更新排行榜失敗:", error);
@@ -63,152 +54,232 @@ class UserRank {
     updated_at: number;
 }
 
-const columns = [
-    {
-        key: "rank",
-        label: "名次",
-        tdAlign: "center" as const,
-        thAlign: "center" as const,
-        sortable: true,
-        sortingOptions: ["desc" as const, "asc" as const, null],
-    },
-    {
-        key: "display",
-        label: "名稱",
-        tdAlign: "center" as const,
-        thAlign: "center" as const,
-    },
-    {
-        key: "coin",
-        label: "水星幣",
-        tdAlign: "center" as const,
-        thAlign: "center" as const,
-    },
-    {
-        key: "updated_at",
-        label: "最近出現",
-        tdAlign: "center" as const,
-        thAlign: "center" as const,
-        sortable: true,
-        sortingOptions: ["desc" as const, "asc" as const, null],
-    },
-];
-
-function rankStyle(rank: number) {
-    if (rank === 1) {
-        return "text-yellow-400 font-bold text-2xl";
-    } else if (rank === 2) {
-        return "text-zinc-400 font-bold text-xl";
-    } else if (rank === 3) {
-        return "text-amber-600 font-bold text-lg";
-    } else {
-        return "text-white";
-    }
+function chineseDate(ts: number): string {
+    const d = new Date(ts);
+    return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`;
 }
 
-function rankEmoji(rank: number) {
-    if (rank == 1) {
-        return "🥇";
-    } else if (rank === 2) {
-        return "🥈";
-    } else if (rank === 3) {
-        return "🥉";
-    } else {
-        return "ㅤ"; // Invisible character to maintain layout
-    }
+function medalColor(rank: number): string {
+    if (rank === 1) return "text-yellow-400";
+    if (rank === 2) return "text-zinc-300";
+    if (rank === 3) return "text-amber-500";
+    return "text-zinc-600";
+}
+
+function medalBg(rank: number): string {
+    if (rank === 1) return "bg-yellow-400/15";
+    if (rank === 2) return "bg-zinc-300/10";
+    if (rank === 3) return "bg-amber-500/10";
+    return "bg-zinc-700/50";
+}
+
+function medalBorder(rank: number): string {
+    if (rank === 1) return "border-yellow-400/40";
+    if (rank === 2) return "border-zinc-300/25";
+    if (rank === 3) return "border-amber-500/30";
+    return "border-zinc-700/50";
+}
+
+function medalEmoji(rank: number): string {
+    if (rank === 1) return "👑";
+    if (rank === 2) return "🥈";
+    if (rank === 3) return "🥉";
+    return "";
+}
+
+function podiumOrder(rank: number): string {
+    if (rank === 1) return "md:order-2";
+    if (rank === 2) return "md:order-1";
+    if (rank === 3) return "md:order-3";
+    return "";
 }
 </script>
 
 <template>
-    <div
-        class="flex h-14 w-full flex-row items-center justify-between gap-4 px-2"
+    <main
+        class="lb-page min-h-[calc(100vh-48px)] text-[#f7f7f8] pt-10 pb-5 px-4 max-md:pt-16 max-md:pb-4 max-md:px-3"
     >
-        <h1 class="ml-12 text-2xl font-semibold">水星排行</h1>
-        <div class="flex items-center">
-            <VaButton preset="plain" @click="loadLeaderboard()"
-                ><VaIcon><ArrowClockwise24Filled /></VaIcon
-            ></VaButton>
-            <p class="text-zinc-400 sm:text-right ml-2">
-                這裡顯示的是水星幣的排行榜，每次直播獲得的水星幣都會在這裡顯示。
-            </p>
-        </div>
-    </div>
-    <VaDivider class="w-full !mt-0 !mb-2" />
-
-    <ViewportHeight>
-        <VaCard class="mx-2 overflow-hidden rounded-xl h-full">
-            <VaScrollContainer
-                vertical
-                color="#e0feb4"
-                size="medium"
-                class="h-full"
+        <div class="w-full max-w-[1200px] mx-auto">
+            <!-- Header -->
+            <div
+                class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6 px-4"
             >
-                <VaDataTable
-                    :items="leaderboard"
-                    :columns="columns"
-                    style="
-                        --va-data-table-hover-color: #357286;
-                        --va-data-table-thead-background: var(
-                            --va-background-element
-                        );
-                        --va-data-table-thead-border: 0;
-                        height: 100%;
-                    "
-                    :virtual-scroller="false"
-                    sticky-header
-                    hoverable
+                <div>
+                    <h1 class="text-3xl font-bold text-neutral-100">
+                        水星排行
+                    </h1>
+                    <p class="text-sm text-zinc-400 mt-1">
+                        每次直播獲得的水星幣都會在這裡顯示，致敬貢獻最多的水星人
+                    </p>
+                </div>
+                <VaButton
+                    preset="plain"
+                    color="info"
+                    @click="loadLeaderboard()"
+                    class="self-start"
                 >
-                    <template
-                        v-for="column in columns"
-                        #[`header(${column.key})`]="{ label }"
-                        :key="column.key"
+                    <VaIcon><ArrowClockwise24Filled /></VaIcon>
+                    <span class="ml-1 text-sm">重新整理</span>
+                </VaButton>
+            </div>
+
+            <!-- Top 3 Podium -->
+            <section
+                v-if="leaderboard.length > 0"
+                class="px-4 mb-8"
+                aria-label="前三名榮譽榜"
+            >
+                <div
+                    class="flex flex-col md:flex-row items-center justify-center gap-4 md:gap-6 md:items-end"
+                >
+                    <div
+                        v-for="user in leaderboard.slice(0, 3)"
+                        :key="user.rank"
+                        :class="[
+                            podiumOrder(user.rank),
+                            medalBorder(user.rank),
+                            medalBg(user.rank),
+                        ]"
+                        class="flex flex-col items-center rounded-2xl border p-5 md:p-6 w-full max-w-[240px] backdrop-blur-sm transition-all duration-300 hover:scale-105 hover:[box-shadow:0_8px_32px_rgba(0,0,0,0.35)]"
                     >
-                        <div class="text-sm text-center">
-                            {{ label }}
+                        <!-- Rank badge -->
+                        <div
+                            :class="medalColor(user.rank)"
+                            class="text-4xl mb-2"
+                        >
+                            {{ medalEmoji(user.rank) }}
                         </div>
-                    </template>
-                    <template #cell(rank)="{ value, row }">
-                        <div class="text-center">
-                            <div :class="rankStyle(row.rowData.rank)">
-                                {{ rankEmoji(row.rowData.rank) }}第
-                                {{ value }} 名
-                            </div>
+                        <div
+                            :class="medalColor(user.rank)"
+                            class="text-lg font-bold tracking-wider"
+                        >
+                            第 {{ user.rank }} 名
                         </div>
-                    </template>
-                    <template #cell(display)="{ value, row }">
-                        <div class="text-center">
-                            <VaButton
-                                :href="`https://www.youtube.com/channel/${row.rowData.youtube}`"
-                                target="_blank"
-                                preset="plain"
-                                rel="noopener noreferrer"
+
+                        <!-- Avatar initial -->
+                        <div
+                            :class="[
+                                medalBg(user.rank),
+                                medalBorder(user.rank),
+                                medalColor(user.rank),
+                            ]"
+                            class="w-16 h-16 rounded-full border flex items-center justify-center text-2xl font-bold my-3"
+                        >
+                            {{ user.display.charAt(0) }}
+                        </div>
+
+                        <!-- Name -->
+                        <a
+                            :href="`https://www.youtube.com/channel/${user.youtube}`"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            :class="medalColor(user.rank)"
+                            class="text-base font-semibold text-center hover:underline truncate max-w-full"
+                        >
+                            {{ user.display }}
+                        </a>
+
+                        <!-- Coin -->
+                        <div class="flex items-baseline gap-1 mt-2">
+                            <span
+                                :class="medalColor(user.rank)"
+                                class="text-2xl font-extrabold"
                             >
-                                <div :class="rankStyle(row.rowData.rank)">
-                                    {{ value }}
-                                </div>
-                            </VaButton>
+                                {{ user.coin.toLocaleString() }}
+                            </span>
+                            <span class="text-xs text-zinc-500">水星幣</span>
                         </div>
-                    </template>
-                    <template #cell(coin)="{ value, row }">
-                        <div class="text-center">
-                            <div :class="rankStyle(row.rowData.rank)">
-                                {{ value }}
+
+                        <!-- Last seen -->
+                        <div class="text-xs text-zinc-500 mt-2">
+                            {{ chineseDate(user.updated_at) }}
+                        </div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Empty state -->
+            <section
+                v-if="leaderboard.length === 0"
+                class="flex flex-col items-center justify-center py-20 text-zinc-500"
+            >
+                <div class="text-6xl mb-4">🏆</div>
+                <p class="text-lg">尚無排行資料</p>
+                <p class="text-sm mt-1">點擊重新整理按鈕載入排行榜</p>
+            </section>
+
+            <!-- Remaining ranks (4–50) -->
+            <section
+                v-if="leaderboard.length > 3"
+                class="px-4 pb-8"
+                aria-label="其餘排行"
+            >
+                <div class="flex items-center gap-3 mb-3">
+                    <VaDivider class="grow !m-0" />
+                    <span class="text-sm text-zinc-500 whitespace-nowrap"
+                        >第 4 – {{ leaderboard.length }} 名</span
+                    >
+                    <VaDivider class="grow !m-0" />
+                </div>
+
+                <div
+                    class="grid gap-2 [grid-template-columns:repeat(auto-fill,minmax(320px,1fr))] max-md:grid-cols-1"
+                >
+                    <div
+                        v-for="user in leaderboard.slice(3)"
+                        :key="user.rank"
+                        class="flex items-center gap-4 rounded-xl border border-zinc-700/40 bg-zinc-800/40 backdrop-blur-sm px-4 py-3 transition-colors transition-transform duration-200 hover:translate-x-0.5 hover:bg-zinc-700/40 hover:border-zinc-600/50"
+                    >
+                        <!-- Rank number -->
+                        <div
+                            class="w-10 h-10 rounded-full bg-zinc-700/60 flex items-center justify-center text-sm font-bold text-zinc-300 shrink-0"
+                        >
+                            {{ user.rank }}
+                        </div>
+
+                        <!-- Name -->
+                        <div class="flex-1 min-w-0">
+                            <a
+                                :href="`https://www.youtube.com/channel/${user.youtube}`"
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                class="text-zinc-200 font-medium hover:text-info hover:underline truncate block"
+                            >
+                                {{ user.display }}
+                            </a>
+                            <div class="text-xs text-zinc-500">
+                                {{ chineseDate(user.updated_at) }}
                             </div>
                         </div>
-                    </template>
-                    <template #cell(updated_at)="{ value }">
-                        <div class="text-center">
-                            {{ new Date(value).toDateString() }}
+
+                        <!-- Coin -->
+                        <div class="flex items-baseline gap-1 shrink-0">
+                            <span
+                                class="text-lg font-bold text-zinc-200 tabular-nums"
+                            >
+                                {{ user.coin.toLocaleString() }}
+                            </span>
                         </div>
-                    </template>
-                </VaDataTable>
-            </VaScrollContainer>
-        </VaCard>
-    </ViewportHeight>
+                    </div>
+                </div>
+            </section>
+        </div>
+    </main>
 </template>
 
-<style scoped>
-:deep(.va-data-table__thead) {
-    background-color: var(--va-background-element);
+<style>
+.lb-page {
+    background:
+        radial-gradient(
+            circle at 50% 0%,
+            rgba(255, 215, 0, 0.08),
+            transparent 36rem
+        ),
+        radial-gradient(
+            circle at 15% 0%,
+            rgba(88, 166, 255, 0.2),
+            transparent 32rem
+        ),
+        linear-gradient(135deg, #0f1117 0%, #16191f 48%, #101318 100%);
 }
 </style>

--- a/web/components/Leaderboard.vue
+++ b/web/components/Leaderboard.vue
@@ -87,10 +87,23 @@ function medalEmoji(rank: number): string {
     return "";
 }
 
+function avatarInitial(display: string): string {
+    const stripped = display.replace(/^@+/, "");
+    const firstAlpha = stripped.match(/[a-zA-Z]/);
+    return firstAlpha ? firstAlpha[0].toUpperCase() : stripped.charAt(0);
+}
+
 function podiumOrder(rank: number): string {
     if (rank === 1) return "md:order-2";
     if (rank === 2) return "md:order-1";
     if (rank === 3) return "md:order-3";
+    return "";
+}
+
+function podiumSize(rank: number): string {
+    if (rank === 1) return "md:pt-14 md:pb-10";
+    if (rank === 2) return "md:pt-10 md:pb-8";
+    if (rank === 3) return "md:pt-7 md:pb-6";
     return "";
 }
 </script>
@@ -137,10 +150,11 @@ function podiumOrder(rank: number): string {
                         :key="user.rank"
                         :class="[
                             podiumOrder(user.rank),
+                            podiumSize(user.rank),
                             medalBorder(user.rank),
                             medalBg(user.rank),
                         ]"
-                        class="flex flex-col items-center rounded-2xl border p-5 md:p-6 w-full max-w-[240px] backdrop-blur-sm transition-all duration-300 hover:scale-105 hover:[box-shadow:0_8px_32px_rgba(0,0,0,0.35)]"
+                        class="flex flex-col items-center rounded-2xl border p-5 w-full max-w-[240px] backdrop-blur-sm transition-all duration-300 hover:scale-105 hover:[box-shadow:0_8px_32px_rgba(0,0,0,0.35)]"
                     >
                         <!-- Rank badge -->
                         <div
@@ -165,7 +179,7 @@ function podiumOrder(rank: number): string {
                             ]"
                             class="w-16 h-16 rounded-full border flex items-center justify-center text-2xl font-bold my-3"
                         >
-                            {{ user.display.charAt(0) }}
+                            {{ avatarInitial(user.display) }}
                         </div>
 
                         <!-- Name -->

--- a/web/components/wheel/Wheel.vue
+++ b/web/components/wheel/Wheel.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-// TODO: Update Wheel style
 import Spinner from "./Spinner.vue";
 import {
     ref,
@@ -260,117 +259,221 @@ const isSubmitAvailable: ComputedRef<boolean> = computed(() => {
 </script>
 
 <template>
-    <div class="mt-8 m-auto w-11/12">
-        <div class="flex w-full justify-evenly">
-            <div class="wheel-wrapper w-2/5 mt-4">
-                <Spinner ref="wheelRef" :items="items" @winner="handleWinner" />
+    <main
+        class="wheel-page min-h-[calc(100vh-48px)] text-[#f7f7f8] pt-10 pb-5 px-4 max-md:pt-16 max-md:pb-4 max-md:px-3"
+    >
+        <div class="w-full max-w-[1400px] mx-auto">
+            <!-- Page Header -->
+            <div class="mb-8 px-4">
+                <h1 class="text-3xl font-bold text-neutral-100">幸運轉盤</h1>
+                <div
+                    class="mt-1.5 flex flex-wrap items-center gap-x-4 gap-y-1.5"
+                >
+                    <p class="text-sm text-zinc-400">
+                        每行一個項目，可使用「項目名稱x權重」設定比重；旋轉後隨機抽出結果
+                    </p>
+                    <!-- API status hashtag -->
+                    <span
+                        class="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-semibold transition-colors duration-300"
+                        :class="
+                            APIstatus === true
+                                ? 'bg-lime-400/10 text-lime-400'
+                                : APIstatus === null
+                                  ? 'bg-gray-400/10 text-gray-400'
+                                  : 'bg-red-400/10 text-red-400'
+                        "
+                    >
+                        <VaIcon size="small">
+                            <ArrowSyncCheckmark24Filled v-if="APIstatus" />
+                            <ArrowClockwise24Filled
+                                v-else-if="APIstatus == null"
+                            />
+                            <AlertCircleOutline v-else />
+                        </VaIcon>
+                        {{
+                            APIstatus === true
+                                ? "已連接到伺服器"
+                                : APIstatus === null
+                                  ? "正在連接伺服器..."
+                                  : "無法連接到伺服器"
+                        }}
+                    </span>
+                    <!-- Auth status hashtag -->
+                    <span
+                        class="inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs font-semibold transition-colors duration-300"
+                        :class="
+                            authState.isAuthenticated
+                                ? 'bg-lime-400/10 text-lime-400'
+                                : 'bg-red-400/10 text-red-400'
+                        "
+                    >
+                        <VaIcon size="small">
+                            <PersonLock20Filled
+                                v-if="authState.isAuthenticated"
+                            />
+                            <PresenceBlocked12Regular v-else />
+                        </VaIcon>
+                        {{
+                            authState.isAuthenticated
+                                ? "已登入管理權限"
+                                : "尚未登入管理權限"
+                        }}
+                    </span>
+                </div>
             </div>
-            <div class="w-1/5">
-                <div class="va-h4">待抽區 ({{ count(textArea) }}個)</div>
-                <VaTextarea
-                    v-model="textArea"
-                    color="#ffffff"
-                    :resize="false"
-                    class="w-full h-96 mt-8"
-                    :readonly="isLeftAreaLocked"
-                />
-                <VaButton
-                    class="w-full mt-8"
-                    @click="spin"
-                    :disabled="isSpinning || count(textArea) == 0"
-                >
-                    旋轉
-                </VaButton>
-                <VaButton
-                    class="w-full mt-8"
-                    @click="openStatusModal"
-                    :disabled="!isSubmitAvailable"
-                >
-                    完成抽選
-                </VaButton>
-                <div class="text-red-500 text-right" v-if="!isSubmitAvailable">
-                    <VaDivider color="danger" orientation="right">
-                        停用
-                    </VaDivider>
+
+            <!-- Three-Panel Layout -->
+            <div
+                class="flex flex-col lg:flex-row items-start gap-6 px-4 max-md:px-0"
+            >
+                <!-- Wheel Panel -->
+                <div class="w-full lg:w-[44%]">
+                    <div
+                        class="wheel-panel rounded-2xl border border-[rgba(255,255,255,0.06)] bg-[rgba(18,21,27,0.92)] backdrop-blur-sm p-6 lg:p-8"
+                    >
+                        <Spinner
+                            ref="wheelRef"
+                            :items="items"
+                            @winner="handleWinner"
+                        />
+                    </div>
                 </div>
 
-                <div class="h-44"></div>
-            </div>
-            <div class="w-1/5">
-                <div class="va-h4">抽中區 ({{ count(textArea2) }}個)</div>
-                <VaTextarea
-                    v-model="textArea2"
-                    color="#ffffff"
-                    :resize="false"
-                    class="w-full h-96 mt-8"
-                />
-                <div class="flex w-full justify-between">
-                    <VaButton class="w-3/5 mt-8" @click="modal2.show = true">
-                        清空
-                    </VaButton>
-                    <VaSwitch
-                        class="mt-8"
-                        v-model="clearRightArea"
-                        off-color="#1ccba2"
-                        color="#3444a2"
-                        style="--va-switch-checker-background-color: #252723"
-                        false-inner-label="待抽區"
-                        true-inner-label="抽中區"
-                        :disabled="isSpinning"
-                    />
-                </div>
-                <div class="flex flex-col gap-2 mt-10">
+                <!-- Left Panel: 待抽區 -->
+                <div class="w-full lg:w-[27%]">
                     <div
-                        class="flex flex-row gap-2 text-sm text-lime-400"
-                        v-if="APIstatus"
+                        class="panel-card rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(18,21,27,0.92)] backdrop-blur-sm p-5 flex flex-col"
                     >
-                        <VaIcon size="large">
-                            <ArrowSyncCheckmark24Filled />
-                        </VaIcon>
-                        已連接到伺服器
-                    </div>
-                    <div
-                        class="flex flex-row gap-2 text-sm text-gray-400"
-                        v-else-if="APIstatus == null"
-                    >
-                        <VaIcon size="large">
-                            <ArrowClockwise24Filled />
-                        </VaIcon>
-                        正在連接伺服器...
-                    </div>
-                    <div
-                        class="flex flex-row gap-2 text-sm text-red-600"
-                        v-else
-                    >
-                        <VaIcon size="large">
-                            <AlertCircleOutline />
-                        </VaIcon>
-                        無法連接到伺服器
-                    </div>
+                        <!-- Panel Header -->
+                        <div class="flex items-center justify-between mb-4">
+                            <div>
+                                <span
+                                    class="text-[0.72rem] font-extrabold uppercase tracking-normal text-[#45d483]"
+                                    >Draw Pool</span
+                                >
+                                <h2
+                                    class="mt-[0.1rem] text-base font-extrabold text-[#f7f7f8]"
+                                >
+                                    待抽區
+                                </h2>
+                            </div>
+                            <span
+                                class="rounded-full bg-[#45d483]/15 px-3 py-1 text-xs font-bold text-[#45d483]"
+                            >
+                                {{ count(textArea) }} 個
+                            </span>
+                        </div>
 
-                    <div
-                        class="flex flex-row gap-2 text-sm text-lime-400"
-                        v-if="authState.isAuthenticated"
-                    >
-                        <VaIcon size="large">
-                            <PersonLock20Filled />
-                        </VaIcon>
-                        已登入管理權限
-                    </div>
-                    <div
-                        class="flex flex-row gap-2 text-sm text-red-600"
-                        v-else
-                    >
-                        <VaIcon size="large">
-                            <PresenceBlocked12Regular />
-                        </VaIcon>
-                        尚未登入管理權限
+                        <!-- Textarea -->
+                        <VaTextarea
+                            v-model="textArea"
+                            :resize="false"
+                            class="w-full h-80"
+                            :class="{
+                                'pointer-events-none opacity-50': isLeftAreaLocked,
+                            }"
+                            :readonly="isLeftAreaLocked"
+                            placeholder="每行一個項目&#10;可加權重：項目名稱x3"
+                        />
+
+                        <!-- Action Buttons -->
+                        <div class="flex flex-col gap-3 mt-4">
+                            <VaButton
+                                class="w-full rounded-xl !normal-case font-bold"
+                                size="large"
+                                @click="spin"
+                                :disabled="
+                                    isSpinning || count(textArea) == 0
+                                "
+                            >
+                                🎰 旋轉
+                            </VaButton>
+
+                            <VaButton
+                                class="w-full rounded-xl !normal-case font-bold"
+                                size="large"
+                                color="success"
+                                @click="openStatusModal"
+                                :disabled="!isSubmitAvailable"
+                            >
+                                📤 完成抽選
+                            </VaButton>
+
+                            <!-- Submit unavailable notice -->
+                            <div
+                                v-if="!isSubmitAvailable"
+                                class="flex items-center gap-2 text-xs text-zinc-500"
+                            >
+                                <VaDivider class="grow !m-0" />
+                                <span class="shrink-0">停用</span>
+                                <VaDivider class="grow !m-0" />
+                            </div>
+                        </div>
                     </div>
                 </div>
-                <div class="h-44"></div>
+
+                <!-- Right Panel: 抽中區 -->
+                <div class="w-full lg:w-[27%]">
+                    <div
+                        class="panel-card rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(18,21,27,0.92)] backdrop-blur-sm p-5 flex flex-col"
+                    >
+                        <!-- Panel Header -->
+                        <div class="flex items-center justify-between mb-4">
+                            <div>
+                                <span
+                                    class="text-[0.72rem] font-extrabold uppercase tracking-normal text-amber-400"
+                                    >Results</span
+                                >
+                                <h2
+                                    class="mt-[0.1rem] text-base font-extrabold text-[#f7f7f8]"
+                                >
+                                    抽中區
+                                </h2>
+                            </div>
+                            <span
+                                class="rounded-full bg-amber-400/15 px-3 py-1 text-xs font-bold text-amber-400"
+                            >
+                                {{ count(textArea2) }} 個
+                            </span>
+                        </div>
+
+                        <!-- Textarea -->
+                        <VaTextarea
+                            v-model="textArea2"
+                            :resize="false"
+                            class="w-full h-80"
+                            placeholder="抽中的項目會移動到這裡"
+                        />
+
+                        <!-- Clear Row -->
+                        <div
+                            class="flex items-center justify-between gap-3 mt-4"
+                        >
+                            <VaButton
+                                class="rounded-xl !normal-case font-bold flex-1"
+                                color="danger"
+                                size="small"
+                                @click="modal2.show = true"
+                            >
+                                清空
+                            </VaButton>
+                            <VaSwitch
+                                v-model="clearRightArea"
+                                off-color="#1ccba2"
+                                color="#3444a2"
+                                style="--va-switch-checker-background-color: #252723"
+                                false-inner-label="待抽區"
+                                true-inner-label="抽中區"
+                                :disabled="isSpinning"
+                                size="small"
+                            />
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
 
+        <!-- Modals -->
         <VaModal
             v-model="modal.show"
             noDismiss
@@ -389,7 +492,9 @@ const isSubmitAvailable: ComputedRef<boolean> = computed(() => {
             :mobile-fullscreen="false"
             @ok="
                 () => {
-                    clearRightArea == true ? (textArea2 = '') : (textArea = '');
+                    clearRightArea == true
+                        ? (textArea2 = '')
+                        : (textArea = '');
                     initializeWheel();
                 }
             "
@@ -473,10 +578,25 @@ const isSubmitAvailable: ComputedRef<boolean> = computed(() => {
                 廣播失敗，請檢查權限或伺服器狀態。
             </div>
         </VaModal>
-    </div>
+    </main>
 </template>
 
-<style scoped>
+<style>
+.wheel-page {
+    background:
+        radial-gradient(
+            circle at 50% 0%,
+            rgba(69, 212, 131, 0.06),
+            transparent 36rem
+        ),
+        radial-gradient(
+            circle at 15% 0%,
+            rgba(88, 166, 255, 0.2),
+            transparent 32rem
+        ),
+        linear-gradient(135deg, #0f1117 0%, #16191f 48%, #101318 100%);
+}
+
 .pointer-img {
     width: clamp(8rem, 18vw, 10rem);
     height: auto;

--- a/web/components/wheel/Wheel.vue
+++ b/web/components/wheel/Wheel.vue
@@ -1,33 +1,32 @@
 <script setup lang="ts">
-import Spinner from "./Spinner.vue";
+import api from "@composables/axios";
 import {
-    ref,
-    onMounted,
-    reactive,
-    onBeforeUnmount,
     computed,
     ComputedRef,
+    onBeforeUnmount,
+    onMounted,
+    reactive,
+    ref,
 } from "vue";
 import {
-    VaTextarea,
-    VaButton,
-    VaModal,
-    VaSwitch,
-    VaPopover,
-    VaIcon,
-    VaDivider,
     useToast,
+    VaButton,
+    VaIcon,
+    VaModal,
+    VaPopover,
+    VaSwitch,
+    VaTextarea,
 } from "vuestic-ui";
-import api from "@composables/axios";
+import Spinner from "./Spinner.vue";
 
-import { AlertCircleOutline } from "@vicons/ionicons5";
+import { useAuthState } from "@/composables/authState";
 import {
     ArrowClockwise24Filled,
     ArrowSyncCheckmark24Filled,
     PersonLock20Filled,
     PresenceBlocked12Regular,
 } from "@vicons/fluent";
-import { useAuthState } from "@/composables/authState";
+import { AlertCircleOutline } from "@vicons/ionicons5";
 
 document.title = "幸運轉盤 - 水星人的夢幻樂園";
 

--- a/web/components/wheel/Wheel.vue
+++ b/web/components/wheel/Wheel.vue
@@ -399,14 +399,71 @@ const isSubmitAvailable: ComputedRef<boolean> = computed(() => {
                                 📤 完成抽選
                             </VaButton>
 
-                            <!-- Submit unavailable notice -->
+                            <!-- Submit conditions checklist -->
                             <div
                                 v-if="!isSubmitAvailable"
-                                class="flex items-center gap-2 text-xs text-zinc-500"
+                                class="grid grid-cols-2 gap-1.5 px-0.5 text-xs"
                             >
-                                <VaDivider class="grow !m-0" />
-                                <span class="shrink-0">停用</span>
-                                <VaDivider class="grow !m-0" />
+                                <div
+                                    class="flex items-center gap-1 rounded-md px-1.5 py-1"
+                                    :class="
+                                        isSpinning
+                                            ? 'text-zinc-500 bg-zinc-500/5'
+                                            : 'text-lime-400 bg-lime-400/5'
+                                    "
+                                >
+                                    <span class="text-sm">⏳</span>
+                                    <span>{{
+                                        isSpinning
+                                            ? "轉盤旋轉中"
+                                            : "轉盤未在旋轉"
+                                    }}</span>
+                                </div>
+                                <div
+                                    class="flex items-center gap-1 rounded-md px-1.5 py-1"
+                                    :class="
+                                        count(textArea2) === 0
+                                            ? 'text-zinc-500 bg-zinc-500/5'
+                                            : 'text-lime-400 bg-lime-400/5'
+                                    "
+                                >
+                                    <span class="text-sm">📭</span>
+                                    <span>{{
+                                        count(textArea2) === 0
+                                            ? "抽中區無項目"
+                                            : "抽中區有項目"
+                                    }}</span>
+                                </div>
+                                <div
+                                    class="flex items-center gap-1 rounded-md px-1.5 py-1"
+                                    :class="
+                                        !APIstatus
+                                            ? 'text-zinc-500 bg-zinc-500/5'
+                                            : 'text-lime-400 bg-lime-400/5'
+                                    "
+                                >
+                                    <span class="text-sm">🔌</span>
+                                    <span>{{
+                                        !APIstatus
+                                            ? "未連接到伺服器"
+                                            : "已連接到伺服器"
+                                    }}</span>
+                                </div>
+                                <div
+                                    class="flex items-center gap-1 rounded-md px-1.5 py-1"
+                                    :class="
+                                        !authState.isAuthenticated
+                                            ? 'text-zinc-500 bg-zinc-500/5'
+                                            : 'text-lime-400 bg-lime-400/5'
+                                    "
+                                >
+                                    <span class="text-sm">🔒</span>
+                                    <span>{{
+                                        !authState.isAuthenticated
+                                            ? "未登入管理權限"
+                                            : "已登入管理權限"
+                                    }}</span>
+                                </div>
                             </div>
                         </div>
                     </div>
@@ -446,27 +503,45 @@ const isSubmitAvailable: ComputedRef<boolean> = computed(() => {
                         />
 
                         <!-- Clear Row -->
-                        <div
-                            class="flex items-center justify-between gap-3 mt-4"
-                        >
+                        <div class="flex flex-col gap-3 mt-4">
                             <VaButton
-                                class="rounded-xl !normal-case font-bold flex-1"
+                                class="w-full rounded-xl !normal-case font-bold"
+                                size="large"
                                 color="danger"
-                                size="small"
                                 @click="modal2.show = true"
                             >
                                 清空
                             </VaButton>
-                            <VaSwitch
-                                v-model="clearRightArea"
-                                off-color="#1ccba2"
-                                color="#3444a2"
-                                style="--va-switch-checker-background-color: #252723"
-                                false-inner-label="待抽區"
-                                true-inner-label="抽中區"
-                                :disabled="isSpinning"
-                                size="small"
-                            />
+                            <!-- Tab switcher for clear target -->
+                            <div
+                                class="flex w-full rounded-xl overflow-hidden border border-[rgba(255,255,255,0.08)]"
+                                :class="{ 'pointer-events-none opacity-50': isSpinning }"
+                            >
+                                <button
+                                    class="flex-1 py-2.5 text-sm font-bold transition-colors duration-200"
+                                    :class="
+                                        !clearRightArea
+                                            ? 'bg-[#1ccba2] text-white'
+                                            : 'bg-transparent text-zinc-500 hover:text-zinc-300'
+                                    "
+                                    :disabled="isSpinning"
+                                    @click="clearRightArea = false"
+                                >
+                                    待抽區
+                                </button>
+                                <button
+                                    class="flex-1 py-2.5 text-sm font-bold transition-colors duration-200"
+                                    :class="
+                                        clearRightArea
+                                            ? 'bg-[#3444a2] text-white'
+                                            : 'bg-transparent text-zinc-500 hover:text-zinc-300'
+                                    "
+                                    :disabled="isSpinning"
+                                    @click="clearRightArea = true"
+                                >
+                                    抽中區
+                                </button>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/web/components/wheel/Wheel.vue
+++ b/web/components/wheel/Wheel.vue
@@ -370,7 +370,8 @@ const isSubmitAvailable: ComputedRef<boolean> = computed(() => {
                             :resize="false"
                             class="w-full h-80"
                             :class="{
-                                'pointer-events-none opacity-50': isLeftAreaLocked,
+                                'pointer-events-none opacity-50':
+                                    isLeftAreaLocked,
                             }"
                             :readonly="isLeftAreaLocked"
                             placeholder="每行一個項目&#10;可加權重：項目名稱x3"
@@ -382,9 +383,7 @@ const isSubmitAvailable: ComputedRef<boolean> = computed(() => {
                                 class="w-full rounded-xl !normal-case font-bold"
                                 size="large"
                                 @click="spin"
-                                :disabled="
-                                    isSpinning || count(textArea) == 0
-                                "
+                                :disabled="isSpinning || count(textArea) == 0"
                             >
                                 🎰 旋轉
                             </VaButton>
@@ -515,7 +514,10 @@ const isSubmitAvailable: ComputedRef<boolean> = computed(() => {
                             <!-- Tab switcher for clear target -->
                             <div
                                 class="flex w-full rounded-xl overflow-hidden border border-[rgba(255,255,255,0.08)]"
-                                :class="{ 'pointer-events-none opacity-50': isSpinning }"
+                                :class="{
+                                    'pointer-events-none opacity-50':
+                                        isSpinning,
+                                }"
                             >
                                 <button
                                     class="flex-1 py-2.5 text-sm font-bold transition-colors duration-200"
@@ -567,9 +569,7 @@ const isSubmitAvailable: ComputedRef<boolean> = computed(() => {
             :mobile-fullscreen="false"
             @ok="
                 () => {
-                    clearRightArea == true
-                        ? (textArea2 = '')
-                        : (textArea = '');
+                    clearRightArea == true ? (textArea2 = '') : (textArea = '');
                     initializeWheel();
                 }
             "


### PR DESCRIPTION
## Summary

Redesigns the Leaderboard and Wheel pages to match the site's modern dark design language.

### Leaderboard
- New podium section with tiered heights for top 3
- First-alphabet avatars with medal-colored styling
- Gold refresh button with cooldown timer and last-updated timestamp
- Responsive grid layout for ranks 4–50
- Chinese date formatting

### Wheel (幸運轉盤)
- Dark gradient page background matching Penalty/Leaderboard
- Three-panel card layout with consistent border/backdrop-blur styling
- Page header with title and inline status hashtag labels
- Panel headers using the site's eyebrow + title typography pattern
- Right-panel tab switcher for clear-target selection
- Persistent 2x2 submit-condition checklist with dynamic positive/negative wording
- Status indicators moved to header as compact hashtag pills

🤖 Generated with [Claude Code](https://claude.com/claude-code)
