### PR TITLE
Apply purple gradient background to Publication and Contact pages

### DIFF
--- a/web/components/contact/Contact.vue
+++ b/web/components/contact/Contact.vue
@@ -6,8 +6,9 @@ import ContactCard from "./ContactCard.vue";
 </script>
 
 <template>
-    <div class="mt-4 m-auto w-11/12">
-        <div class="flex flex-row justify-center gap-6 pt-10">
+    <div class="contact-page min-h-[calc(100vh-48px)] text-[#f7f7f8] pt-10 pb-5 px-4 max-md:pt-16 max-md:pb-4 max-md:px-3">
+        <div class="w-full max-w-[1400px] mx-auto">
+            <div class="flex flex-row justify-center gap-6 pt-10">
             <ContactCard
                 name1="惡靈"
                 name2="Oreki"
@@ -70,5 +71,23 @@ import ContactCard from "./ContactCard.vue";
                 allowfullscreen
             ></iframe>
         </div>
+        </div>
     </div>
 </template>
+
+<style>
+.contact-page {
+    background:
+        radial-gradient(
+            circle at 50% 0%,
+            rgba(142, 120, 255, 0.09),
+            transparent 36rem
+        ),
+        radial-gradient(
+            circle at 15% 0%,
+            rgba(88, 166, 255, 0.2),
+            transparent 32rem
+        ),
+        linear-gradient(135deg, #0f1117 0%, #16191f 48%, #101318 100%);
+}
+</style>

--- a/web/components/contact/Contact.vue
+++ b/web/components/contact/Contact.vue
@@ -6,71 +6,75 @@ import ContactCard from "./ContactCard.vue";
 </script>
 
 <template>
-    <div class="contact-page min-h-[calc(100vh-48px)] text-[#f7f7f8] pt-10 pb-5 px-4 max-md:pt-16 max-md:pb-4 max-md:px-3">
+    <div
+        class="contact-page min-h-[calc(100vh-48px)] text-[#f7f7f8] pt-10 pb-5 px-4 max-md:pt-16 max-md:pb-4 max-md:px-3"
+    >
         <div class="w-full max-w-[1400px] mx-auto">
             <div class="flex flex-row justify-center gap-6 pt-10">
-            <ContactCard
-                name1="惡靈"
-                name2="Oreki"
-                :tags="['水星神', '伺服器總管', '爭議協調與排解委員']"
-                discord="oreki20"
-            >
-                <template #avatar>
-                    <img
-                        src="/images/admin_avatars/oreki20.webp"
-                        class="w-full h-full object-contain"
-                        slot="avatar"
-                    />
-                </template>
-            </ContactCard>
-            <ContactCard
-                name1="香榭"
-                name2="Champsing"
-                :tags="['伺服器維護', '網站設計', '爭議協調與排解委員']"
-                discord="champsing"
-            >
-                <template #avatar>
-                    <img
-                        src="/images/admin_avatars/champsing.webp"
-                        class="w-full h-full object-contain"
-                        slot="avatar"
-                    />
-                </template>
-                <template #rcm-link>
-                    <VaButton
-                        preset="primary"
-                        color="warning"
-                        href="https://tslyric.com/"
-                        rel="noopener noreferrer"
-                        target="_blank"
-                    >
-                        <div class="text-base text-orange-300">🎵音樂欣賞</div>
-                    </VaButton>
-                </template>
-            </ContactCard>
-        </div>
-        <VaDivider class="!mb-2" />
-        <div class="w-full mb-6">
-            <iframe
-                class="m-auto"
-                src="https://www.youtube.com/embed/YTB35De0Bs8?si=cP5rNghSy_WQLl8m"
-                title="YouTube video player"
-                frameborder="0"
-                height="400"
-                width="800"
-                allow="
-                    accelerometer;
-                    autoplay;
-                    clipboard-write;
-                    encrypted-media;
-                    gyroscope;
-                    picture-in-picture;
-                    web-share;
-                "
-                referrerpolicy="strict-origin-when-cross-origin"
-                allowfullscreen
-            ></iframe>
-        </div>
+                <ContactCard
+                    name1="惡靈"
+                    name2="Oreki"
+                    :tags="['水星神', '伺服器總管', '爭議協調與排解委員']"
+                    discord="oreki20"
+                >
+                    <template #avatar>
+                        <img
+                            src="/images/admin_avatars/oreki20.webp"
+                            class="w-full h-full object-contain"
+                            slot="avatar"
+                        />
+                    </template>
+                </ContactCard>
+                <ContactCard
+                    name1="香榭"
+                    name2="Champsing"
+                    :tags="['伺服器維護', '網站設計', '爭議協調與排解委員']"
+                    discord="champsing"
+                >
+                    <template #avatar>
+                        <img
+                            src="/images/admin_avatars/champsing.webp"
+                            class="w-full h-full object-contain"
+                            slot="avatar"
+                        />
+                    </template>
+                    <template #rcm-link>
+                        <VaButton
+                            preset="primary"
+                            color="warning"
+                            href="https://tslyric.com/"
+                            rel="noopener noreferrer"
+                            target="_blank"
+                        >
+                            <div class="text-base text-orange-300">
+                                🎵音樂欣賞
+                            </div>
+                        </VaButton>
+                    </template>
+                </ContactCard>
+            </div>
+            <VaDivider class="!mb-2" />
+            <div class="w-full mb-6">
+                <iframe
+                    class="m-auto"
+                    src="https://www.youtube.com/embed/YTB35De0Bs8?si=cP5rNghSy_WQLl8m"
+                    title="YouTube video player"
+                    frameborder="0"
+                    height="400"
+                    width="800"
+                    allow="
+                        accelerometer;
+                        autoplay;
+                        clipboard-write;
+                        encrypted-media;
+                        gyroscope;
+                        picture-in-picture;
+                        web-share;
+                    "
+                    referrerpolicy="strict-origin-when-cross-origin"
+                    allowfullscreen
+                ></iframe>
+            </div>
         </div>
     </div>
 </template>

--- a/web/components/publication/Publication.vue
+++ b/web/components/publication/Publication.vue
@@ -13,42 +13,61 @@ const activeTab = ref<"join" | "publication" | "archive">("join");
 </script>
 
 <template>
-    <div class="pt-16 m-auto w-11/12">
-        <VaTabs v-model="activeTab" color="info" center grow>
-            <template #tabs>
-                <VaTab name="join" color="info">加入伺服</VaTab>
-                <VaTab name="publication" color="info">法規與資料</VaTab>
-                <VaTab name="archive" color="info">地圖檔</VaTab>
-            </template>
-        </VaTabs>
+    <div class="publication-page min-h-[calc(100vh-48px)] text-[#f7f7f8] pt-10 pb-5 px-4 max-md:pt-16 max-md:pb-4 max-md:px-3">
+        <div class="w-full max-w-[1400px] mx-auto">
+            <VaTabs v-model="activeTab" color="info" center grow>
+                <template #tabs>
+                    <VaTab name="join" color="info">加入伺服</VaTab>
+                    <VaTab name="publication" color="info">法規與資料</VaTab>
+                    <VaTab name="archive" color="info">地圖檔</VaTab>
+                </template>
+            </VaTabs>
 
-        <div class="mt-10">
-            <Join v-if="activeTab === 'join'" />
+            <div class="mt-10">
+                <Join v-if="activeTab === 'join'" />
 
-            <div v-if="activeTab === 'publication'">
-                <!-- 如果沒有新版本水星法可以註解起來 -->
-                <!-- 
-                <NewLaw /> 
-                <VaDivider /> 
-                -->
-                <div class="p-10">
-                    <Law />
-                </div>
-            </div>
-
-            <div v-if="activeTab === 'archive'" class="mt-4 mb-6">
-                <div
-                    class="flex flex-row items-center justify-center gap-4 text-neutral-100 mt-4 mb-10"
-                >
-                    <div class="flex flex-row items-center gap-1">
-                        <VaIcon size="large">
-                            <WindowNew20Filled />
-                        </VaIcon>
-                        <div class="text-base">將開啟新分頁</div>
+                <div v-if="activeTab === 'publication'">
+                    <!-- 如果沒有新版本水星法可以註解起來 -->
+                    <!--
+                    <NewLaw />
+                    <VaDivider />
+                    -->
+                    <div class="p-10">
+                        <Law />
                     </div>
                 </div>
-                <Archive />
+
+                <div v-if="activeTab === 'archive'" class="mt-4 mb-6">
+                    <div
+                        class="flex flex-row items-center justify-center gap-4 text-neutral-100 mt-4 mb-10"
+                    >
+                        <div class="flex flex-row items-center gap-1">
+                            <VaIcon size="large">
+                                <WindowNew20Filled />
+                            </VaIcon>
+                            <div class="text-base">將開啟新分頁</div>
+                        </div>
+                    </div>
+                    <Archive />
+                </div>
             </div>
         </div>
     </div>
 </template>
+
+<style>
+.publication-page {
+    background:
+        radial-gradient(
+            circle at 50% 0%,
+            rgba(142, 120, 255, 0.09),
+            transparent 36rem
+        ),
+        radial-gradient(
+            circle at 15% 0%,
+            rgba(88, 166, 255, 0.2),
+            transparent 32rem
+        ),
+        linear-gradient(135deg, #0f1117 0%, #16191f 48%, #101318 100%);
+}
+</style>

--- a/web/components/publication/Publication.vue
+++ b/web/components/publication/Publication.vue
@@ -13,7 +13,9 @@ const activeTab = ref<"join" | "publication" | "archive">("join");
 </script>
 
 <template>
-    <div class="publication-page min-h-[calc(100vh-48px)] text-[#f7f7f8] pt-10 pb-5 px-4 max-md:pt-16 max-md:pb-4 max-md:px-3">
+    <div
+        class="publication-page min-h-[calc(100vh-48px)] text-[#f7f7f8] pt-10 pb-5 px-4 max-md:pt-16 max-md:pb-4 max-md:px-3"
+    >
         <div class="w-full max-w-[1400px] mx-auto">
             <VaTabs v-model="activeTab" color="info" center grow>
                 <template #tabs>


### PR DESCRIPTION

## Summary

Replace the default background on the **Publication** and **Contact** pages with the same "mysteric purple" dark gradient design used by the Leaderboard and Wheel pages, deprecating the pure black background.

## Changes

- **`Publication.vue`** — Added `publication-page` class with a three-layer purple gradient background
- **`Contact.vue`** — Added `contact-page` class with the same gradient

## Gradient composition

- Top-center purple accent: `rgba(142, 120, 255, 0.09)`
- Top-left blue accent: `rgba(88, 166, 255, 0.2)` (shared with Leaderboard/Wheel)
- Base dark gradient: `linear-gradient(135deg, #0f1117 → #16191f → #101318)` (shared with Leaderboard/Wheel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)