### PR TITLE
fix: read auth token from Authorization header instead of query/body

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mercury_land"
-version = "2.23.0"
+version = "2.23.1"
 authors = ["logicfan", "champsing"]
 edition = "2024"
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "mercury_land",
-    "version": "2.23.0",
+    "version": "2.23.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "mercury_land",
-            "version": "2.23.0",
+            "version": "2.23.1",
             "dependencies": {
                 "@vicons/fa": "^0.12.0",
                 "@vicons/fluent": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "mercury_land",
     "private": true,
-    "version": "2.23.0",
+    "version": "2.23.1",
     "type": "module",
     "scripts": {
         "dev": "vite",

--- a/src/webpage/anonymous/list.rs
+++ b/src/webpage/anonymous/list.rs
@@ -3,15 +3,9 @@ use crate::{
     error::ServerError,
     webpage::auth,
 };
-use actix_web::{HttpResponse, Responder, get, web};
+use actix_web::{HttpRequest, HttpResponse, Responder, get};
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
 use serde::Serialize;
-
-#[derive(Debug, Deserialize)]
-pub struct Query {
-    pub token: String,
-}
 
 #[derive(Debug, Serialize)]
 pub struct AnonymousWithUser {
@@ -23,8 +17,8 @@ pub struct AnonymousWithUser {
 }
 
 #[get("/api/anonymous/list")]
-pub async fn handler(query: web::Query<Query>) -> Result<impl Responder, ServerError> {
-    if !auth::verify(&query.token) {
+pub async fn handler(req: HttpRequest) -> Result<impl Responder, ServerError> {
+    if !auth::extract_and_verify(&req) {
         return Ok(HttpResponse::Forbidden().finish());
     }
     let mut connection = database::get_connection()?;

--- a/src/webpage/auth/mod.rs
+++ b/src/webpage/auth/mod.rs
@@ -2,6 +2,7 @@ pub mod google;
 pub mod login;
 pub mod tick;
 
+use actix_web::HttpRequest;
 use hmac::{Hmac, Mac};
 use jwt::{Header, Token, VerifyWithKey};
 use rand::RngCore;
@@ -39,6 +40,17 @@ pub fn verify(token: &str) -> bool {
             let claims: &Claims = token.claims();
             claims.iat < now && claims.exp > now
         })
+        .unwrap_or(false)
+}
+
+/// Extracts a Bearer token from the `Authorization` header and verifies it.
+/// Returns `true` if the header is present, well-formed, and the token is valid.
+pub fn extract_and_verify(req: &HttpRequest) -> bool {
+    req.headers()
+        .get("Authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+        .map(|token| verify(token))
         .unwrap_or(false)
 }
 

--- a/src/webpage/setting/backup.rs
+++ b/src/webpage/setting/backup.rs
@@ -1,16 +1,10 @@
 use crate::{database, error::ServerError, webpage::auth};
-use actix_web::{HttpResponse, Responder, get, web};
+use actix_web::{HttpRequest, HttpResponse, Responder, get};
 use chrono::Utc;
-use serde::Deserialize;
-
-#[derive(Debug, Deserialize)]
-pub struct Query {
-    pub token: String,
-}
 
 #[get("/api/setting/backup")]
-pub async fn handler(query: web::Query<Query>) -> Result<impl Responder, ServerError> {
-    if !auth::verify(&query.token) {
+pub async fn handler(req: HttpRequest) -> Result<impl Responder, ServerError> {
+    if !auth::extract_and_verify(&req) {
         return Ok(HttpResponse::Forbidden().finish());
     }
 

--- a/src/webpage/setting/get.rs
+++ b/src/webpage/setting/get.rs
@@ -1,19 +1,21 @@
 use crate::database::config::Config;
 use crate::error::ServerError;
 use crate::webpage::auth;
-use actix_web::{HttpResponse, Responder, get, web};
+use actix_web::{HttpRequest, HttpResponse, Responder, get, web};
 use serde::Deserialize;
 use serde_json;
 
 #[derive(Debug, Deserialize)]
 pub struct Query {
-    pub token: String,
     pub id: i32,
 }
 
 #[get("/api/setting/config")]
-pub async fn handler(query: web::Query<Query>) -> Result<impl Responder, ServerError> {
-    if !auth::verify(&query.token) {
+pub async fn handler(
+    req: HttpRequest,
+    query: web::Query<Query>,
+) -> Result<impl Responder, ServerError> {
+    if !auth::extract_and_verify(&req) {
         return Ok(HttpResponse::Forbidden().finish());
     }
 

--- a/src/webpage/setting/set.rs
+++ b/src/webpage/setting/set.rs
@@ -1,19 +1,21 @@
 use crate::database::config::Config;
 use crate::error::ServerError;
 use crate::webpage::auth;
-use actix_web::{HttpResponse, Responder, post, web};
+use actix_web::{HttpRequest, HttpResponse, Responder, post, web};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
 pub struct Request {
-    pub token: String,
     pub id: i32,
     pub value: String,
 }
 
 #[post("/api/setting/config")]
-pub async fn handler(request: web::Json<Request>) -> Result<impl Responder, ServerError> {
-    if !auth::verify(&request.token) {
+pub async fn handler(
+    req: HttpRequest,
+    request: web::Json<Request>,
+) -> Result<impl Responder, ServerError> {
+    if !auth::extract_and_verify(&req) {
         return Ok(HttpResponse::Forbidden().finish());
     }
 


### PR DESCRIPTION
@
## Problem

The admin settings page at `/setting` was broken with:
```
Query deserialize error: missing field `token`
```

**Root cause**: The backend handlers (`/api/setting/config`, `/api/setting/backup`, `/api/anonymous/list`) expected the JWT token as a query parameter (GET) or JSON body field (POST). The frontend axios interceptor already sends the token in the `Authorization: Bearer <token>` HTTP header — but the backend never read it from there.

## Fix

- Added `extract_and_verify()` to `src/webpage/auth/mod.rs` that reads the Bearer token from the `Authorization` header
- Updated all four handlers to use it instead of deserializing `token` from query params / JSON body
- Removed unused `token` fields from deserialization structs and cleaned up imports

## Changes

| File | Change |
|------|--------|
| `src/webpage/auth/mod.rs` | Added `extract_and_verify(&HttpRequest) -> bool` |
| `src/webpage/setting/get.rs` | Read token from header, trim `Query` struct |
| `src/webpage/setting/set.rs` | Read token from header, trim `Request` struct |
| `src/webpage/setting/backup.rs` | Read token from header, remove dead `Query` struct |
| `src/webpage/anonymous/list.rs` | Read token from header, remove dead `Query` struct |

🤖 Generated with [Claude Code](https://claude.com/claude-code)